### PR TITLE
remove unnecessary nesting

### DIFF
--- a/src/circshift.jl
+++ b/src/circshift.jl
@@ -1,10 +1,10 @@
 """
     circshift(v::AbstractArray, n)
 
-Return a `CircShiftedArray` object which lazily represents the array `v`
-shifted circularly by `n`.
-The second argument `n` specifies the amount to shift circularly in each dimension.
-If it is an integer, it is assumed to refer to the first dimension.
+Return a `CircShiftedArray` object which lazily represents the array `v` shifted
+circularly by `n` (an `Integer` or a `Tuple` of `Integer`s).
+If the number of dimensions of `v` exceeds the length of `n`, the shift in the
+remaining dimensions is assumed to be `0`.
 
 # Examples
 

--- a/src/circshift.jl
+++ b/src/circshift.jl
@@ -1,9 +1,10 @@
 """
     circshift(v::AbstractArray, n)
 
-Return a `CircShiftedArray` object, with underlying data `v`. The second argument gives the amount
-to circularly shift in each dimension. If it is an integer, it is assumed to refer to the
-first dimension.
+Return a `CircShiftedArray` object which lazily represents the array `v`
+shifted circularly by `n`.
+The second argument `n` specifies the amount to shift circularly in each dimension.
+If it is an integer, it is assumed to refer to the first dimension.
 
 # Examples
 

--- a/src/circshiftedarray.jl
+++ b/src/circshiftedarray.jl
@@ -1,9 +1,10 @@
 """
     CircShiftedArray(parent::AbstractArray, shifts)
 
-Custom `AbstractArray` object to store an `AbstractArray` `parent` circularly shifted by `shifts` steps (where `shifts` is
-a `Tuple` with one `shift` value per dimension of `parent`). Note that `shift` is modified with a modulo operation and does
-not store the passed value but instead a positive number which leads to an equivalent shift.
+Custom `AbstractArray` object to store an `AbstractArray` `parent` circularly shifted
+by `shifts` steps (where `shifts` is a `Tuple` with one `shift` value per dimension of `parent`).
+Note that `shift` is modified with a modulo operation and does not store the passed value
+but instead a positive number which leads to an equivalent shift.
 Use `copy` to collect the values of a `CircShiftedArray` into a normal `Array`.
 
 # Examples
@@ -34,6 +35,11 @@ struct CircShiftedArray{T, N, S<:AbstractArray} <: AbstractArray{T, N}
         shifts = map(mod, padded_tuple(p, n), size(p))
         return new{T, N, typeof(p)}(p, shifts)
     end
+end
+
+function CircShiftedArray(c::CircShiftedArray, n = ())
+    shifts = map(+, ShiftedArrays.shifts(c), padded_tuple(c, n))
+    return CircShiftedArray(parent(c), shifts)
 end
 
 """

--- a/src/circshiftedarray.jl
+++ b/src/circshiftedarray.jl
@@ -7,6 +7,10 @@ Note that `shift` is modified with a modulo operation and does not store the pas
 but instead a positive number which leads to an equivalent shift.
 Use `copy` to collect the values of a `CircShiftedArray` into a normal `Array`.
 
+!!! note
+    If `parent` is itself a `CircShiftedArray`, the constructor does not nest
+    `CircShiftedArray` objects but rather combines the shifts additively.
+
 # Examples
 
 ```jldoctest circshiftedarray

--- a/src/circshiftedarray.jl
+++ b/src/circshiftedarray.jl
@@ -3,9 +3,11 @@
 
 Custom `AbstractArray` object to store an `AbstractArray` `parent` circularly shifted
 by `shifts` steps (where `shifts` is a `Tuple` with one `shift` value per dimension of `parent`).
-Note that `shift` is modified with a modulo operation and does not store the passed value
-but instead a positive number which leads to an equivalent shift.
 Use `copy` to collect the values of a `CircShiftedArray` into a normal `Array`.
+
+!!! note
+    `shift` is modified with a modulo operation and does not store the passed value
+    but instead a nonnegative number which leads to an equivalent shift.
 
 !!! note
     If `parent` is itself a `CircShiftedArray`, the constructor does not nest

--- a/src/fftshift.jl
+++ b/src/fftshift.jl
@@ -48,7 +48,7 @@ julia> ShiftedArrays.fftshift([1 0 0; 0 0 0; 0 0 0], (1,))
 ```
 """
 function fftshift(x::AbstractArray{T, N}, dims=ntuple(identity, Val(N))) where {T, N}
-    ShiftedArrays.circshift(x, ft_center_diff(size(x), dims))
+    return ShiftedArrays.circshift(x, ft_center_diff(size(x), dims))
 end
 
 """
@@ -79,5 +79,5 @@ julia> ShiftedArrays.ifftshift([0 1 0; 0 0 0; 0 0 0], (2,))
 ```
 """
 function ifftshift(x::AbstractArray{T, N}, dims=ntuple(identity, Val(N))) where {T, N}
-    ShiftedArrays.circshift(x, map(-, ft_center_diff(size(x), dims)))
+    return ShiftedArrays.circshift(x, map(-, ft_center_diff(size(x), dims)))
 end

--- a/src/lag.jl
+++ b/src/lag.jl
@@ -1,9 +1,10 @@
 """
     lag(v::AbstractArray, n = 1; default = missing)
 
-Return a `ShiftedArray` object which lazily represents the array `v` shifted by `n`.
-The second argument `n` specifies the amount to shift in each dimension.
-If it is an integer, it is assumed to refer to the first dimension.
+Return a `ShiftedArray` object which lazily represents the array `v` shifted
+by `n` (an `Integer` or a `Tuple` of `Integer`s).
+If the number of dimensions of `v` exceeds the length of `n`, the shift in the
+remaining dimensions is assumed to be `0`.
 `default` specifies a default value to return when out of bounds in the original array.
 
 # Examples
@@ -55,9 +56,9 @@ end
     lead(v::AbstractArray, n = 1; default = missing)
 
 Return a `ShiftedArray` object which lazily represents the array `v` shifted
-negatively by `n`.
-The second argument `n` specifies the amount to shift negatively in each dimension.
-If it is an integer, it is assumed to refer to the first dimension.
+negatively by `n` (an `Integer` or a `Tuple` of `Integer`s).
+If the number of dimensions of `v` exceeds the length of `n`, the shift in the
+remaining dimensions is assumed to be `0`.
 `default` specifies a default value to return when out of bounds in the original array.
 
 # Examples

--- a/src/lag.jl
+++ b/src/lag.jl
@@ -1,9 +1,10 @@
 """
     lag(v::AbstractArray, n = 1; default = missing)
 
-Return a `ShiftedArray` object, with underlying data `v`. The second argument gives the amount
-to shift in each dimension. If it is an integer, it is assumed to refer to the first dimension.
-`default` specifies a default value when you are out of bounds.
+Return a `ShiftedArray` object which lazily represents the array `v` shifted by `n`.
+The second argument `n` specifies the amount to shift in each dimension.
+If it is an integer, it is assumed to refer to the first dimension.
+`default` specifies a default value to return when out of bounds in the original array.
 
 # Examples
 
@@ -53,9 +54,11 @@ end
 """
     lead(v::AbstractArray, n = 1; default = missing)
 
-Return a `ShiftedArray` object, with underlying data `v`. The second argument gives the amount
-to shift negatively in each dimension. If it is an integer, it is assumed to refer
-to the first dimension. `default` specifies a default value when you are out of bounds.
+Return a `ShiftedArray` object which lazily represents the array `v` shifted
+negatively by `n`.
+The second argument `n` specifies the amount to shift negatively in each dimension.
+If it is an integer, it is assumed to refer to the first dimension.
+`default` specifies a default value to return when out of bounds in the original array.
 
 # Examples
 

--- a/src/lag.jl
+++ b/src/lag.jl
@@ -46,7 +46,9 @@ julia> s = lag(v, (0, 2))
  missing  missing  4  8
 ```
 """
-lag(v::AbstractArray, n = 1; default = missing) = ShiftedArray(v, n; default = default)
+function lag(v::AbstractArray, n = 1; default = ShiftedArrays.default(v))
+    return ShiftedArray(v, n; default = default)
+end
 
 """
     lead(v::AbstractArray, n = 1; default = missing)
@@ -96,4 +98,6 @@ julia> s = lead(v, (0, 2))
  12  16  missing  missing
 ```
 """
-lead(v::AbstractArray, n = 1; default = missing) = ShiftedArray(v, map(-, n); default = default)
+function lead(v::AbstractArray, n = 1; default = ShiftedArrays.default(v))
+    return ShiftedArray(v, map(-, n); default = default)
+end

--- a/src/shiftedarray.jl
+++ b/src/shiftedarray.jl
@@ -31,6 +31,11 @@ is a valid index for `s.parent`, and `s.v[i, ...] == default` otherwise.
 Use `copy` to collect the values of a `ShiftedArray` into a normal `Array`.
 The recommended constructor is `ShiftedArray(parent, shifts; default = missing)`.
 
+!!! note
+    If `parent` is itself a `ShiftedArray` with a compatible default value,
+    the constructor does not nest `ShiftedArray` objects but rather combines
+    the shifts additively.
+
 # Examples
 
 ```jldoctest shiftedarray

--- a/src/shiftedarray.jl
+++ b/src/shiftedarray.jl
@@ -24,12 +24,12 @@ padded_tuple(v::AbstractArray, s) = ntuple(i -> i ≤ length(s) ? s[i] : 0, ndim
 """
     ShiftedArray(parent::AbstractArray, shifts, default)
 
-Custom `AbstractArray` object to store an `AbstractArray` `parent` shifted by `shifts` steps (where `shifts` is
-a `Tuple` with one `shift` value per dimension of `parent`).
+Custom `AbstractArray` object to store an `AbstractArray` `parent` shifted by `shifts` steps
+(where `shifts` is a `Tuple` with one `shift` value per dimension of `parent`).
 For `s::ShiftedArray`, `s[i...] == s.parent[map(-, i, s.shifts)...]` if `map(-, i, s.shifts)`
 is a valid index for `s.parent`, and `s.v[i, ...] == default` otherwise.
 Use `copy` to collect the values of a `ShiftedArray` into a normal `Array`.
-The recommended constructor is `ShiftedArray(parent, shifts; default = missing)`
+The recommended constructor is `ShiftedArray(parent, shifts; default = missing)`.
 
 # Examples
 
@@ -78,8 +78,19 @@ struct ShiftedArray{T, M, N, S<:AbstractArray} <: AbstractArray{Union{T, M}, N}
     default::M
 end
 
-ShiftedArray(v::AbstractArray{T, N}, n = (); default::M = missing) where {T, N, M} =
-     ShiftedArray{T, M, N, typeof(v)}(v, padded_tuple(v, n), default)
+# low-level private constructor to handle type parameters
+function shiftedarray(v::AbstractArray{T, N}, shifts, default::M) where {T, N, M}
+    return ShiftedArray{T, M, N, typeof(v)}(v, padded_tuple(v, shifts), default)
+end
+
+function ShiftedArray(v::AbstractArray, n = (); default = ShiftedArrays.default(v))
+    return if v isa ShiftedArray && default === ShiftedArrays.default(v)
+        shifts = map(+, ShiftedArrays.shifts(v), padded_tuple(v, n))
+        shiftedarray(parent(v), shifts, default)
+    else
+        shiftedarray(v, n, default)
+    end
+end
 
 """
     ShiftedVector{T, S<:AbstractArray}
@@ -88,7 +99,9 @@ Shorthand for `ShiftedArray{T, 1, S}`.
 """
 const ShiftedVector{T, M, S<:AbstractArray} = ShiftedArray{T, M, 1, S}
 
-ShiftedVector(v::AbstractVector, n = (); default = missing) = ShiftedArray(v, n; default = default)
+function ShiftedVector(v::AbstractVector, n = (); default = ShiftedArrays.default(v))
+    return ShiftedArray(v, n; default = default)
+end
 
 size(s::ShiftedArray) = size(parent(s))
 axes(s::ShiftedArray) = axes(parent(s))
@@ -121,3 +134,5 @@ shifts(s::ShiftedArray) = s.shifts
 Return default value.
 """
 default(s::ShiftedArray) = s.default
+
+default(::AbstractArray) = missing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,14 @@ using AbstractFFTs
     @test default(svneg) == -100
     @test copy(svneg) == coalesce.(sv, -100)
     @test isequal(sv[1:3], Union{Int64, Missing}[3, 5, 4])
+    svnest = ShiftedVector(ShiftedVector(v, 1), 2)
+    sv = ShiftedVector(v, 3)
+    @test sv === svnest
+    sv = ShiftedVector(v, 2, default = nothing)
+    sv1 = ShiftedVector(sv, 1)
+    sv2 = ShiftedVector(sv, 1, default = 0)
+    @test isequal(collect(sv1), [nothing, nothing, nothing, 1])
+    @test isequal(collect(sv2), [0, nothing, nothing, 1])
 end
 
 @testset "ShiftedArray" begin
@@ -38,6 +46,20 @@ end
     @test all(sneg .== coalesce.(s, default(sneg)))
     @test checkbounds(Bool, sv, 2, 2)
     @test !checkbounds(Bool, sv, 123, 123)
+    svnest = ShiftedArray(ShiftedArray(v, (1, 1)), 2)
+    sv = ShiftedArray(v, (3, 1))
+    @test sv === svnest
+    sv = ShiftedArray(v, 2, default = nothing)
+    sv1 = ShiftedArray(sv, (1, 1))
+    sv2 = ShiftedArray(sv, (1, 1), default = 0)
+    @test isequal(collect(sv1), [nothing   nothing   nothing   nothing
+                                 nothing   nothing   nothing   nothing
+                                 nothing   nothing   nothing   nothing
+                                 nothing   1         5         9      ])
+    @test isequal(collect(sv2), [0   0         0         0
+                                 0   nothing   nothing   nothing
+                                 0   nothing   nothing   nothing
+                                 0   1         5         9      ])
 end
 
 @testset "padded_tuple" begin
@@ -81,6 +103,9 @@ end
     @test sv === setindex!(sv, 12, 3) 
     @test checkbounds(Bool, sv, 2)
     @test !checkbounds(Bool, sv, 123)
+    sv = CircShiftedArray(v, 3)
+    svnest = CircShiftedArray(CircShiftedArray(v, 2), 1)
+    @test sv === svnest
 end
 
 @testset "CircShiftedArray" begin
@@ -98,6 +123,9 @@ end
                                10 14 2 6;
                                11 15 3 7;
                                12 16 4 8])
+    sv = CircShiftedArray(v, 3)
+    svnest = CircShiftedArray(CircShiftedArray(v, 2), 1)
+    @test sv === svnest
 end
 
 @testset "circshift" begin
@@ -105,6 +133,9 @@ end
     @test all(circshift(v, (1, -1)) .== ShiftedArrays.circshift(v, (1, -1)))
     @test all(circshift(v, (1,)) .== ShiftedArrays.circshift(v, (1,)))
     @test all(circshift(v, 3) .== ShiftedArrays.circshift(v, 3))
+    sv = ShiftedArrays.circshift(v, 3)
+    svnest = ShiftedArrays.circshift(ShiftedArrays.circshift(v, 2), 1)
+    @test sv === svnest
 end
 
 @testset "fftshift and ifftshift" begin
@@ -147,4 +178,7 @@ end
     @test isequal(diff2, [-7, -9, missing, missing])
 
     @test all(lead(v, 2, default = -100) .== coalesce.(lead(v, 2), -100))
+
+    @test lag(lag(v, 1), 2) === lag(v, 3)
+    @test lead(lead(v, 1), 2) === lead(v, 3)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,11 +55,11 @@ end
     @test isequal(collect(sv1), [nothing   nothing   nothing   nothing
                                  nothing   nothing   nothing   nothing
                                  nothing   nothing   nothing   nothing
-                                 nothing   1         5         9      ])
-    @test isequal(collect(sv2), [0   0         0         0
+                                 nothing  1         5         9      ])
+    @test isequal(collect(sv2), [0  0         0         0
                                  0   nothing   nothing   nothing
                                  0   nothing   nothing   nothing
-                                 0   1         5         9      ])
+                                 0  1         5         9      ])
 end
 
 @testset "padded_tuple" begin


### PR DESCRIPTION
Fix #50. This actually takes the slightly more radical approach of avoiding nesting whenever possible from the constructor.

Other than the more efficient storage, there is a small difference in behavior in that now `lag(v, 1)` (if `v` is a `ShiftedArray`) respects the default value of `v`. So for instance

```julia
julia> using ShiftedArrays

julia> v = ShiftedVector(rand(3), 1, default = NaN)
3-element ShiftedVector{Float64, Float64, Vector{Float64}}:
 NaN
   0.41510884185926944
   0.3917724425282777

julia> lag(v, 1)
3-element ShiftedVector{Float64, Float64, Vector{Float64}}:
 NaN
 NaN
   0.41510884185926944
```

which IMO is more reasonable than returning something with values `[missing, NaN, 0.41510884185926944]`, but I think deserves some discussion.

TODO:

- [x] Document the above change in behavior (if we decide to go for it).