### PR TITLE
Update `TagBot.yml` workflow

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,11 +1,15 @@
 name: TagBot
 on:
-  schedule:
-    - cron: 0 * * * *
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
 jobs:
   TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
Noticed there wasn't any git tag for `v2.0.0` here.

The `TagBot` workflow is disabled on this repo https://github.com/JuliaArrays/ShiftedArrays.jl/actions/workflows/TagBot.yml

https://discourse.julialang.org/t/ann-required-updates-to-tagbot-yml/49249